### PR TITLE
Add authentication for admin and user

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'bcrypt', '~> 3.1.7'
 
 # Use Unicorn as the app server
-# gem 'unicorn'
+gem 'unicorn'
 
 # Use Capistrano for deployment
 # gem 'capistrano-rails', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    kgio (2.10.0)
     launchy (2.4.3)
       addressable (~> 2.3)
     loofah (2.0.3)
@@ -143,6 +144,7 @@ GEM
       activesupport (= 4.2.6)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    raindrops (0.16.0)
     rake (11.2.2)
     rdoc (4.2.2)
       json (~> 1.4)
@@ -190,6 +192,9 @@ GEM
       thread_safe (~> 0.1)
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
+    unicorn (5.1.0)
+      kgio (~> 2.6)
+      raindrops (~> 0.7)
     web-console (2.3.0)
       activemodel (>= 4.0)
       binding_of_caller (>= 0.7.2)
@@ -223,6 +228,7 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   shoulda-matchers
   uglifier (>= 1.3.0)
+  unicorn
   web-console (~> 2.0)
 
 BUNDLED WITH

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  before_action :require_current_user, only: [:show, :update]
+
   def new
     @user = User.new
   end
@@ -24,4 +26,12 @@ class UsersController < ApplicationController
   def user_params
     params.require(:user).permit(:username, :password, :role)
   end
+end
+
+def require_current_user
+  render file: "/public/404" unless current_user?
+end
+
+def current_user?
+  current_user && current_user.default?
 end

--- a/spec/features/admin/admin_cannot_modify_users_data_spec.rb
+++ b/spec/features/admin/admin_cannot_modify_users_data_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+describe 'Admin cannot modify user data', :type => :feature do
+  scenario 'and sees something' do
+    admin = User.create(username: 'Alan', password: 'password', role: 1)
+    allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(admin)
+
+    visit dashboard_path
+
+    expect(page).to have_content("The page you were looking for doesn't exist.")
+  end
+end

--- a/spec/features/admin/user_cannot_view_admin_dashboard_spec.rb
+++ b/spec/features/admin/user_cannot_view_admin_dashboard_spec.rb
@@ -15,4 +15,10 @@ describe "User cannot view admin dashboard", :type => :feature do
 
     expect(page).to have_content("The page you were looking for doesn't exist.")
   end
+
+  scenario 'and when an unregistered user visits admin dashboard they get a 404' do
+    visit admin_dashboard_path
+
+    expect(page).to have_content("The page you were looking for doesn't exist.")
+  end
 end

--- a/spec/features/users/visitor_can_adjust_quantity_of_gnomes_in_bucket_spec.rb
+++ b/spec/features/users/visitor_can_adjust_quantity_of_gnomes_in_bucket_spec.rb
@@ -1,17 +1,4 @@
 require 'rails_helper'
-#Background: My cart has an item in it,
-#When I visit '/cart'
-#then I should see my item with a quantity of 1
-#and when I increase the quantity
-#then my current page should be '/cart'
-#And that item's quantity should reflect the increase
-#and the subtotal for that item should increase
-#and the total for the cart should match that increase
-#and when I decrease the quantity
-#then my current page should be '/cart'
-#and that item's quantity should reflect the decrease
-#and the subtotal for that item should decrease
-#and the total for the cart should match that decrease
 
 describe 'Visitor can adjust quantity of items in cart' do
 


### PR DESCRIPTION
Admin cannot modify user data included. Users cannot currently update their account
info per user stories to date. May need to add that functionality and links.

NOTE: Make sure this includes the test admin_cannot_modify_user_data before merging.
